### PR TITLE
[EnemyControl] Fix #8

### DIFF
--- a/EnemyControl/EnemyControl.lua
+++ b/EnemyControl/EnemyControl.lua
@@ -155,15 +155,10 @@ function EnemyControl.UpdatePools() -- Inject every non-empty biome of the curre
         EnemySets[target] = ModUtil.Table.Copy( pool )
         DebugPrint({Text = "Updated enemy pool for "..biome})
     end
-    for encounter, data in pairs( EncounterData ) do -- If EnemySets is updated without updating EncounterData to match, behaviour is unreliable. Inheritance first
-        if data.InheritFrom then
-            for k, v in ipairs( data.InheritFrom ) do
-                data.EnemySet = EnemySets[EnemyControl.EncounterEnemySets[v]] or data.EnemySet or nil
-                if ModUtil.Path.Get( "data.HardEncounterOverrideValues.EnemySet" ) then
-                    data.HardEncounterOverrideValues.EnemySet = ModUtil.Path.Get( "EnemyControl.EncounterHardEnemySets" )[v] or data.HardEncounterOverrideValues.EnemySet
-                end
-            end
-        end
+    
+	for encounterName, encounterData in pairs( EncounterData ) do -- If EnemySets is updated without updating EncounterData to match, behaviour is unreliable. Inheritance first
+		encounterData.Name = encounterName
+		ProcessDataInheritance( encounterData, EncounterData )
     end
     for encounter, set in pairs( EnemyControl.EncounterEnemySets ) do 
         EncounterData[encounter].EnemySet = ModUtil.Table.Copy( EnemySets[set] )

--- a/EnemyControl/EnemyControl.lua
+++ b/EnemyControl/EnemyControl.lua
@@ -133,6 +133,7 @@ EnemyControl.RuleOverrides = { -- Any overrides to enemy eligibility are made he
 }
 
 function EnemyControl.ReadPreset() --Read current preset and create table of enemies marked as eligible
+    EnemyControl.EligibleEnemies = {}
     local Preset = EnemyControl.Presets[config.EnemySetting]
     local InheritVanilla = EnemyControl.InheritVanilla[config.EnemySetting] or {}
     for biome, _ in pairs(Preset) do
@@ -146,11 +147,12 @@ function EnemyControl.ReadPreset() --Read current preset and create table of ene
 end
 
 function EnemyControl.UpdatePools() -- Inject every non-empty biome of the current preset into the relevant biomes in EnemySets.lua
+    EnemySets = ModUtil.Table.Copy( EnemyControl.VanillaSets )
     DebugPrint({Text = "Enemy preset: "..EnemyControl.config.EnemySetting})
+    local target = nil
     for biome, pool in pairs(EnemyControl.EligibleEnemies) do
-        EnemyControl.Target = RCLib.EncodeEnemySet(biome)
-        EnemyControl.Pool = pool
-        ModUtil.Table.Replace(EnemySets[EnemyControl.Target], EnemyControl.Pool)
+        target = RCLib.EncodeEnemySet(biome)
+        EnemySets[target] = ModUtil.Table.Copy(pool)
         DebugPrint({Text = "Updated enemy pool for "..biome})
     end
 end

--- a/EnemyControl/ReferenceData.lua
+++ b/EnemyControl/ReferenceData.lua
@@ -1,0 +1,45 @@
+EnemyControl.EncounterEnemySets = {
+    Generated = "EnemiesBiome1",
+    GeneratedTartarus = "EnemiesBiome1",
+    DevotionTestTartarus = "EnemiesBiome1Devotion",
+    ThanatosTartarus = "EnemiesBiome1Thanatos",
+    ShrineChallengeTartarus = "ShrineChallengeTartarus",
+    SurvivalTartarus = "EnemiesBiome1Survival",
+    MiniBossWretchAssassin = "EnemiesBiome1MiniBoss",
+    MiniBossSwarmerHelemted = "EnemiesBiome1MiniBoss",
+    MiniBossGrenadier = "EnemiesBiome1MiniBoss",
+    MiniBossSelfDestruct = "EnemiesBiome1MiniBoss",
+    MiniBossPitcher = "EnemiesBiome1MiniBoss",
+    MiniBossWaveFist = "EnemiesBiome1MiniBoss",
+
+    GeneratedAsphodel = "EnemiesBiome2",
+    TimeChallengeAsphodel = "EnemiesBiome2Challenge",
+    DevotionTestAsphodel = "EnemiesBiome2Devotion",
+    ThanatosAsphodel = "EnemiesBiome2Thanatos",
+    ShrineChallengeAsphodel = "ShrineChallengeAsphodel",
+    SurvivalAsphodel = "EnemiesBiome2Survival",
+    WrappingAsphodel = "EnemiesBiome2Wrapping",
+
+    GeneratedElysium = "EnemiesBiome3",
+    TimeChallengeElysium = "EnemiesBiome3",
+    DevotionTestElysium = "EnemiesBiome3Devotion",
+    ShrineChallengeElysium = "ShrineChallengeElysium",
+    SurvivalElysium = "EnemiesBiome3Survival",
+    MiniBossNakedSpawners = "EnemiesBiome3Hard",
+    MiniBossShadeMagic = "EnemiesBiome3Hard",
+
+    GeneratedStyx = "EnemiesBiome4",
+    GeneratedStyxMini = "EnemiesBiome4Mini",
+    GeneratedStyxMiniSingle = "EnemiesBiome4MiniSingle",
+    TimeChallengeStyx = "EnemiesBiome4",
+
+    BaseStyxMiniboss = "EnemiesBiome4MiniBossFodder",
+}
+
+EnemyControl.EncounterHardEnemySets = {
+    GeneratedTartarus = "EnemiesBiome1Hard",
+    GeneratedAsphodel = "EnemiesBiome2Hard",
+    GeneratedElysium = "EnemiesBiome3Hard",
+    GeneratedStyxMini = "EnemiesBiome4MiniHard",
+    GeneratedStyxMiniSingle = "EnemiesBiome4MiniSingle",
+}

--- a/EnemyControl/modfile.txt
+++ b/EnemyControl/modfile.txt
@@ -1,2 +1,3 @@
 :: Enemy Control
 Import "EnemyControl.lua"
+Import "ReferenceData.lua"


### PR DESCRIPTION
ReadPreset and UpdatePools were not correctly clearing EligibleEnemies and EnemySets. These will both now reset to default before preset is read, so you won't have carryover from the previous setting and it'll be correctly reapplied.