### PR TITLE
Add LernieControl mod

### DIFF
--- a/LernieControl/LernieControl.lua
+++ b/LernieControl/LernieControl.lua
@@ -1,0 +1,83 @@
+--[[
+    EnemyControl
+    Authors:
+        SleepSoul (Discord: SleepSoul#6006)
+    Dependencies: ModUtil, RCLib
+    Change the pool of side heads that can be chosen in the Lernie fight.
+]]
+ModUtil.Mod.Register("LernieControl")
+
+local config = {
+    LernieSetting = "Vanilla",
+    AllowIneligibleCombos = false, -- Normally Lernie side heads cannot be the same as the side head, this overrides that. Note that the game can crash if this is not enabled and preset only contains 1 head
+}
+LernieControl.config = config
+
+LernieControl.Presets = {
+    Vanilla = {
+        Heads = {},
+        InheritVanilla = true,
+    },
+    NoPinkHeads = {
+        Heads = {
+            PinkLernieHead = false,
+        },
+        InheritVanilla = true,
+    },
+    NoBlueHeads = {
+        Heads = {
+            BlueLernieHead = false,
+        },
+        InheritVanilla = true,
+    },
+    NoPinkOrBlue = {
+        Heads = {
+            PinkLernieHead = false,
+            BlueLernieHead = false,
+        },
+        InheritVanilla = true,
+    },
+}
+LernieControl.VanillaSet = {}
+LernieControl.VanillaEligibility = {}
+LernieControl.EligibleHeads = {}
+
+function LernieControl.ReadPreset()
+    local preset = LernieControl.Presets[ LernieControl.config.LernieSetting ]
+    if preset.InheritVanilla then
+        RCLib.PopulateMinLength( LernieControl.EligibleHeads, RCLib.RemoveIneligibleStrings( preset.Heads, LernieControl.VanillaSet, RCLib.NameToCode.Bosses ), 2 ) -- Game crashes if there is only one head type in EnemySet
+    else
+        RCLib.PopulateMinLength( LernieControl.EligibleHeads, RCLib.GetEligible( preset.Heads, RCLib.NameToCode.Bosses ), 2 )
+    end
+end
+
+function LernieControl.UpdatePool()
+    DebugPrint({ Text = "Lernie preset: "..LernieControl.config.LernieSetting })
+    ModUtil.Table.Replace( EnemySets.HydraHeads, LernieControl.EligibleHeads )
+
+    if LernieControl.config.AllowIneligibleCombos then
+        ModUtil.Table.MergeKeyed( EncounterData.BossHydra.BlockHeadsByHydraVariant, {
+			HydraHeadImmortal = {},
+			HydraHeadImmortalLavamaker = {},
+			HydraHeadImmortalSummoner = {},
+			HydraHeadImmortalSlammer = {},
+			HydraHeadImmortalWavemaker = {},
+		})
+    else
+        ModUtil.Table.MergeKeyed( EncounterData.BossHydra.BlockHeadsByHydraVariant, LernieControl.VanillaEligibility )
+    end
+end
+
+ModUtil.LoadOnce( function()
+    LernieControl.VanillaSet = ModUtil.Table.Copy( EnemySets.HydraHeads )
+    LernieControl.VanillaEligibility = ModUtil.Table.Copy( EncounterData.BossHydra.BlockHeadsByHydraVariant )
+    LernieControl.ReadPreset()
+    LernieControl.UpdatePool()
+end)
+
+-- When a new run is started, make sure to apply the pool settings
+ModUtil.Path.Wrap("StartNewRun", function ( baseFunc, currentRun )
+    LernieControl.ReadPreset()
+    LernieControl.UpdatePool()
+    return baseFunc( currentRun )
+end, LernieControl)

--- a/LernieControl/LernieControl.lua
+++ b/LernieControl/LernieControl.lua
@@ -16,26 +16,22 @@ LernieControl.config = config
 LernieControl.Presets = {
     Vanilla = {
         Heads = {},
-        InheritVanilla = true,
     },
     NoPinkHeads = {
         Heads = {
             PinkLernieHead = false,
         },
-        InheritVanilla = true,
     },
     NoBlueHeads = {
         Heads = {
             BlueLernieHead = false,
         },
-        InheritVanilla = true,
     },
     NoPinkOrBlue = {
         Heads = {
             PinkLernieHead = false,
             BlueLernieHead = false,
         },
-        InheritVanilla = true,
     },
 }
 LernieControl.VanillaSet = {}
@@ -44,11 +40,8 @@ LernieControl.EligibleHeads = {}
 
 function LernieControl.ReadPreset()
     local preset = LernieControl.Presets[ LernieControl.config.LernieSetting ]
-    if preset.InheritVanilla then
-        RCLib.PopulateMinLength( LernieControl.EligibleHeads, RCLib.RemoveIneligibleStrings( preset.Heads, LernieControl.VanillaSet, RCLib.NameToCode.Bosses ), 2 ) -- Game crashes if there is only one head type in EnemySet
-    else
-        RCLib.PopulateMinLength( LernieControl.EligibleHeads, RCLib.GetEligible( preset.Heads, RCLib.NameToCode.Bosses ), 2 )
-    end
+    local eligibleHeads = RCLib.RemoveIneligibleStrings( preset.Heads, LernieControl.VanillaSet, RCLib.NameToCode.Bosses )
+    RCLib.PopulateMinLength( LernieControl.EligibleHeads, eligibleHeads, 2 ) -- Game crashes if there is only one head type in EnemySet
 end
 
 function LernieControl.UpdatePool()

--- a/LernieControl/modfile.txt
+++ b/LernieControl/modfile.txt
@@ -1,0 +1,2 @@
+:: Lernie Control
+Import "LernieControl.lua"

--- a/RCLib/Map.lua
+++ b/RCLib/Map.lua
@@ -258,17 +258,17 @@ RCLib.NameToCode = {
 
         -- Main Lernie Heads
         OrangeLernie = "HydraHeadImmortal",
-        LavaLernie = "HydraHeadImmortalLavaMaker",
+        LavaLernie = "HydraHeadImmortalLavamaker",
         BlueLernie = "HydraHeadImmortalSlammer",
         GreenLernie = "HydraHeadImmortalSummoner",
-        PinkLernie = "HydraHeadImmortalWaveMaker",
+        PinkLernie = "HydraHeadImmortalWavemaker",
         
         -- Side Lernie Heads
         OrangeLernieHead = "HydraHeadDartmaker",
-        LavaLernieHead = "HydraHeadLavaMaker",
+        LavaLernieHead = "HydraHeadLavamaker",
         BlueLernieHead = "HydraHeadSlammer",
         GreenLernieHead = "HydraHeadSummoner",
-        PinkLernieHead = "HydraHeadWaveMaker",
+        PinkLernieHead = "HydraHeadWavemaker",
 
         LernieEgg = "HydraTooth",
         EliteLernieEgg = "HydraTooth2",


### PR DESCRIPTION
Allows selecting which Lernie side heads can appear (e.g. to remove pink heads). Has handling for if only 1 head type is entered, including option to allow otherwise-illegal combos. Dependent on #21.