### PR TITLE
fix: set CurrentRun.Hero.IsDead to true after QuickReset

### DIFF
--- a/QuickRestart/QuickRestart.lua
+++ b/QuickRestart/QuickRestart.lua
@@ -119,6 +119,9 @@ ModUtil.Path.Context.Wrap("HandleDeath", function ()
         end
 
         baseFunc(argTable)
+        
+        --In some cases IsDead will be set to false by DoPatches() causing the "mirror bug"
+        CurrentRun.Hero.IsDead = true
     end, QuickRestart)
 end, QuickRestart)
 


### PR DESCRIPTION
When quick resetting from chaos to courtyard DoPatches() sets CurrentRun.Hero.IsDead to false (RoomManager 1135), causing the mirror to behave strangely.

Fixes: #11 