### PR TITLE
merge rc/v1.3.1 into main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/), and will follow [Semantic Versioning](https://semver.org/).
 
+## [1.3.1] - 2024-03-19
+
+### Bug fixes
+
+ - Using QuickRestart when in a Chaos Gate no longer causes the mirror to behave strangely [fixed by Pseudonym777](https://github.com/Hades-Speedrunning/HadesSpeedrunningModPack/pull/33/commits/46a1119da2032482e545b6d3b915d8f83a427b74)
+
+
 ## [1.3.0] - 2023-03-20
 
 ### Added

--- a/HadesSpeedrunningModpack/HadesSpeedrunningModpack.lua
+++ b/HadesSpeedrunningModpack/HadesSpeedrunningModpack.lua
@@ -1,6 +1,6 @@
 ModUtil.Mod.Register("HadesSpeedrunningModpack")
 config = {
-  Version = "v1.3.0"
+  Version = "v1.3.1"
 }
 HadesSpeedrunningModpack.config = config
 

--- a/QuickRestart/QuickRestart.lua
+++ b/QuickRestart/QuickRestart.lua
@@ -119,6 +119,9 @@ ModUtil.Path.Context.Wrap("HandleDeath", function ()
         end
 
         baseFunc(argTable)
+        
+        --In some cases IsDead will be set to false by DoPatches() causing the "mirror bug"
+        CurrentRun.Hero.IsDead = true
     end, QuickRestart)
 end, QuickRestart)
 


### PR DESCRIPTION
### Fixes
- When quick resetting from chaos to courtyard DoPatches() sets CurrentRun.Hero.IsDead to false (RoomManager 1135), causing the mirror to behave strangely.